### PR TITLE
Adjust Video Page Hover Behaviour

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -16,7 +16,8 @@ const ListItem = ({
     activeTagChange,
     activeTags,
     onClickValue,
-    onClickFunction
+    onClickFunction,
+    noChangeActiveOnHover,
   } = useContext(ListContext);
   const [visible, setVisible] = useState(true);
   useEffect(() => {
@@ -42,8 +43,10 @@ const ListItem = ({
         }}
         // onBlur={() => setActiveIndex(null)} // commented out because need to keep as active when video is clicked
         onMouseOver={() => {
-          setActiveIndex(index);
-          listItemRef.current.focus(); // set focus to the element when it is hovered
+          if(!noChangeActiveOnHover){
+            setActiveIndex(index);
+            listItemRef.current.focus(); // set focus to the element when it is hovered
+          }
         }}
         onClick={e => {
           e.stopPropagation();

--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -111,10 +111,12 @@ const Video = () => {
     activeIndex,
     setActiveIndex,
     onClickValue: playing,
-    onClickFunction: togglePlaying
+    onClickFunction: togglePlaying,
+    noChangeActiveOnHover: playing ? true : false
   };
   const VideoContext = Provider;
-  const activeItem = activeIndex !== null && listItems[activeIndex];
+  const activeItem = activeIndex !== null ? listItems[activeIndex] : listItems[0];
+  if(activeIndex === null) setActiveIndex(0);
   const itemSize = 36;
   return (
     <VideoContext value={states}>
@@ -129,7 +131,6 @@ const Video = () => {
           }
         }}
       >
-        {/* <ListTitle title="video" size={itemSize}>video</ListTitle> */}
         {activeItem && activeItem.video && (
           <VideoPlayer
             name="video-player"


### PR DESCRIPTION
Add noChangeActiveOnHover to Video Context, add to onMouseOver on ListItem. 

Done in order to prevent currently playing video from changing when hovering over other video items on Video Page.

Added initial active item on Video page to be the first item in the list.

Addressed issues https://github.com/ericauv/ericauv-portfolio/issues/4 and https://github.com/ericauv/ericauv-portfolio/issues/5